### PR TITLE
refactor: fix apply attrs to path

### DIFF
--- a/src/components/Icomoon.vue
+++ b/src/components/Icomoon.vue
@@ -1,6 +1,11 @@
 <template>
   <svg v-if="currentIcon" :viewBox="viewBox" :style="style" v-bind="svgProps">
-    <path v-for="path in paths" :d="path.d" />
+    <path
+      v-for="({ d, ...attrs }, index) in paths"
+      :d="d"
+      :key="index"
+      v-bind="attrs"
+    />
     <title v-if="title">{{ title }}</title>
   </svg>
 </template>


### PR DESCRIPTION
I added v-bind and I destructured the v-for parameters to get all attrs automatically.

The icons with attributes before update:
![image](https://user-images.githubusercontent.com/25128546/192182340-17464591-4aa6-4e11-9ba2-e5105a9292b6.png)

The same icons after update:
![image](https://user-images.githubusercontent.com/25128546/192182390-73468d7f-7f8e-4181-a19b-b6ab4170fbb4.png)
